### PR TITLE
Fix OOV gender guessing for -osť feminines and citation-form echo for soft+o loans

### DIFF
--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -1466,7 +1466,15 @@ impl ISVCore {
         for (idx, c) in chars.iter().enumerate() {
             result.push(*c);
             if idx >= mark_from && "cšžčćńľŕťďśźđj".contains(*c) {
-                result.push('ь');
+                // A LEMMA ending in soft consonant + `o` is a foreign citation
+                // form (adadžo, bandžo): native soft neuters already end in -e
+                // (morje). Marking the softness there would O⇒E-convert the
+                // nominative itself (adadžo → adadže) — the citation form must
+                // echo. Oblique cells are unaffected (the yer is stripped).
+                let before_final_o = idx + 2 == chars.len() && chars.last() == Some(&'o');
+                if !before_final_o {
+                    result.push('ь');
+                }
             }
         }
         result
@@ -1961,6 +1969,11 @@ impl ISVCore {
     pub fn is_ost_class(word: &str) -> bool {
         word.ends_with("ost")
             || word.ends_with("ost́")
+            // The precomposed soft-t spelling (U+0165), the common way the
+            // abstract feminine suffix is written (novosť, točnosť). The
+            // length guard leaves the two 4-char lexical words (kosť f,
+            // gosť m!) to the dictionary lookup instead of the heuristic.
+            || (word.ends_with("osť") && word.chars().count() >= 5)
             || word.ends_with("ěć")
             || word.ends_with("ěč")
             || word.ends_with("eć")

--- a/crates/interslavic/tests/oov_gender_and_citation_echo.rs
+++ b/crates/interslavic/tests/oov_gender_and_citation_echo.rs
@@ -1,0 +1,55 @@
+//! Regression tests for gold-silver-copper/interslavic-rs#5:
+//! out-of-lexicon gender guessing and citation-form echo.
+
+use interslavic::{Case, Number, ISV};
+
+/// An out-of-lexicon abstract noun in -osť must decline as a feminine i-stem
+/// (like kosť), not be guessed masculine (točnosťa/točnosťem was the bug).
+#[test]
+fn oov_ost_nouns_are_feminine_i_stems() {
+    // A nonsense -osť word guaranteed to be outside the dictionary.
+    for w in ["zzzukavosť", "točnosť"] {
+        let gen = ISV::noun(w, Case::Gen, Number::Singular);
+        assert!(
+            gen.ends_with("osti"),
+            "{w}: gen.sg must be the i-stem -osti, got {gen}"
+        );
+        let nom = ISV::noun(w, Case::Nom, Number::Singular);
+        assert_eq!(nom, w, "{w}: nom.sg must echo the citation form");
+        let nom_pl = ISV::noun(w, Case::Nom, Number::Plural);
+        assert!(
+            nom_pl.ends_with("osti"),
+            "{w}: nom.pl must be the i-stem -osti, got {nom_pl}"
+        );
+    }
+}
+
+/// The 4-char lexical words stay with their dictionary genders: kosť is
+/// feminine, gosť is MASCULINE — the length guard keeps the heuristic away.
+#[test]
+fn short_ost_words_keep_dictionary_gender() {
+    assert!(
+        ISV::noun("kosť", Case::Gen, Number::Singular).contains("kosti"),
+        "kosť stays feminine"
+    );
+    let gost_gen = ISV::noun("gosť", Case::Gen, Number::Singular);
+    assert!(
+        !gost_gen.contains("gosti"),
+        "gosť must NOT flip to a feminine i-stem: got {gost_gen}"
+    );
+}
+
+/// Loan lemmas in soft consonant + -o must echo their citation form in the
+/// nominative (adadžo → adadže was the bug); native soft neuters in -e are
+/// untouched.
+#[test]
+fn soft_o_loans_echo_citation_form() {
+    for w in ["adadžo", "bandžo"] {
+        assert_eq!(ISV::noun(w, Case::Nom, Number::Singular), w);
+        // Accusative of an inanimate neuter echoes the nominative.
+        assert_eq!(ISV::noun(w, Case::Acc, Number::Singular), w);
+    }
+    // Native soft neuter unchanged by the fix.
+    assert_eq!(ISV::noun("morje", Case::Nom, Number::Singular), "morje");
+    assert_eq!(ISV::noun("polje", Case::Nom, Number::Singular), "polje");
+}


### PR DESCRIPTION
Addresses #5 (items 1 and 3; item 2 — structured cell output instead of the mixed parenthesis conventions — is a bigger API design question and stays open).

## The two bugs

**1. `is_ost_class` missed the precomposed `"osť"` spelling (U+0165).** It checked `"ost"` and `"ost́"` (t + combining acute) only, so an out-of-lexicon abstract noun like `točnosť` fell through `guess_gender` to **masculine** and declined as a soft o-stem:

| | before | after |
|---|---|---|
| `ISV::noun("točnosť", Gen, Sg)` | `točnosťa` | `točnosti` |
| `ISV::noun("točnosť", Ins, Sg)` | `točnosťem` | (i-stem) |

A `≥ 5 chars` guard keeps the heuristic away from the two 4-char lexical words — `kosť` (f) but crucially `gosť` (**m**) — which the dictionary lookup already handles correctly.

**2. `mark_final_soft_noun_consonants` marked softness before a final `-o`**, which ran the O⇒E conversion on the *citation form itself*: `adadžo → nom.sg adadže`, `bandžo → bandže`. A lemma ending in soft consonant + `o` is a foreign citation form (native soft neuters end in `-e`: morje, polje), so the yer is no longer inserted in that one position. Oblique cells are unaffected — the yer is stripped by `noun_rules` there anyway.

## Verification

- Full crate test suite green; **3 new regression tests** (`crates/interslavic/tests/oov_gender_and_citation_echo.rs`) covering both fixes, the kosť/gosť guard, and native-soft-neuter non-regression (`morje`, `polje`).
- Downstream check against **Slovowiki** (which pins this crate and runs it over all 14,625 official lemmas / 231,977 cells via its `inflect-eval`): with this checkout, its nom.sg-echoes-citation-form invariant goes **99.9% → 100.0%** (the two failures were exactly adadžo/bandžo), its gen.sg diagnostic stays 99.8% (the residue is the indeclinable-loan class: kakao, dur — correct behavior its invariant flags conservatively), its 85-test suite passes, its generation benchmark is byte-identical, and its full site/API export is clean (384k form records, shard budget unchanged).