### PR TITLE
Add morphophonemics module (phono): palatalization/iotation tables + softness

### DIFF
--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -29,6 +29,8 @@ mod known_nouns;
 
 use known_nouns::*;
 
+pub mod phono;
+
 #[derive(Debug, Clone, Default)]
 pub struct ISVCore {}
 

--- a/crates/interslavic-core/src/phono.rs
+++ b/crates/interslavic-core/src/phono.rs
@@ -10,11 +10,13 @@
 //! `šć`, `žđ`), matching the standard "flavored" alphabet.
 //!
 //! Note: the crate still carries a few older, narrower alternation sites that
-//! predate this module — [`crate::ISVCore`]'s velar-only yer-marking used by
-//! the `-es-` neuter nouns, and the currently-unused `iotation_merge`, which
-//! writes the `dž` digraph rather than `đ`. Reconciling those onto this module
-//! is deliberately left as follow-up so the noun/verb declension goldens are
-//! not perturbed; new functionality should build on `phono` directly.
+//! predate this module — the yer-marking palatalization used by the `-es-`
+//! neuter nouns (same k/g/h/c sources as [`PALATALIZATION`], but it appends a
+//! soft-sign and is specific to that stem class), and the currently-unused
+//! `iotation_merge`, which writes the `dž` digraph rather than `đ`. Reconciling
+//! those onto this module is deliberately left as follow-up so the noun/verb
+//! declension goldens are not perturbed; new functionality builds on `phono`
+//! directly.
 
 /// First palatalization at a suffix seam (live before `-ny`, `-ka`/`-ko`/`-ok`,
 /// `-sky`, `-stvo`, `-ec`, `-ica`, `-ina`, `-išče`, `-nik`, and the comparative
@@ -46,15 +48,13 @@ pub const IOTATION: &[(&str, &str)] = &[
 
 /// Whether a stem counts as soft, driving the O⇒E ending alternation and the
 /// comparative `-ejši`/`-ějši` choice. True when the last character is one of
-/// `š ž č c j ć đ ń ľ ŕ`, or the stem ends in the digraph `lj`, `nj`, or `dž`.
+/// `š ž č c j ć đ ń ľ ŕ` — which also covers the palatal digraphs `lj`, `nj`
+/// and `dž`, whose final letter (`j`/`j`/`ž`) is already in the set.
 pub fn is_soft(stem: &str) -> bool {
-    let last = stem.chars().last().unwrap_or(' ');
     matches!(
-        last,
+        stem.chars().last().unwrap_or(' '),
         'š' | 'ž' | 'č' | 'c' | 'j' | 'ć' | 'đ' | 'ń' | 'ľ' | 'ŕ'
-    ) || stem.ends_with("lj")
-        || stem.ends_with("nj")
-        || stem.ends_with("dž")
+    )
 }
 
 /// Apply first palatalization to a stem-final consonant (no-op if the final

--- a/crates/interslavic-core/src/phono.rs
+++ b/crates/interslavic-core/src/phono.rs
@@ -1,0 +1,150 @@
+//! Interslavic morphophonemics: the canonical home for the first-palatalization
+//! and iotation correspondence tables and the stem-softness predicate.
+//!
+//! These alternations are shared by every morphological operation that builds
+//! a form across a suffix seam — declension, degrees of comparison, and word
+//! derivation. Exposing one authoritative table set here keeps consumers from
+//! each re-deriving (and diverging on) the correspondences.
+//!
+//! Orthography: the tables use the etymological Interslavic letters (`ć`, `đ`,
+//! `šć`, `žđ`), matching the standard "flavored" alphabet.
+//!
+//! Note: the crate still carries a few older, narrower alternation sites that
+//! predate this module — [`crate::ISVCore`]'s velar-only yer-marking used by
+//! the `-es-` neuter nouns, and the currently-unused `iotation_merge`, which
+//! writes the `dž` digraph rather than `đ`. Reconciling those onto this module
+//! is deliberately left as follow-up so the noun/verb declension goldens are
+//! not perturbed; new functionality should build on `phono` directly.
+
+/// First palatalization at a suffix seam (live before `-ny`, `-ka`/`-ko`/`-ok`,
+/// `-sky`, `-stvo`, `-ec`, `-ica`, `-ina`, `-išče`, `-nik`, and the comparative
+/// `-ejši`).
+pub const PALATALIZATION: &[(char, char)] = &[('k', 'č'), ('g', 'ž'), ('h', 'š'), ('c', 'č')];
+
+/// Iotation of a stem-final consonant before a `-je-` suffix: s→š, z→ž, t→ć,
+/// d→đ, st→šć, zd→žđ, k→č, g→ž, h→š, labials take bare `j` (lovjeńje),
+/// sonorants soften (děljeńje). Ordered longest-match-first (`st` before `s`,
+/// `zd` before `z`); the order is load-bearing.
+pub const IOTATION: &[(&str, &str)] = &[
+    ("st", "šć"),
+    ("zd", "žđ"),
+    ("s", "š"),
+    ("z", "ž"),
+    ("t", "ć"),
+    ("d", "đ"),
+    ("k", "č"),
+    ("g", "ž"),
+    ("h", "š"),
+    ("l", "lj"),
+    ("n", "nj"),
+    ("r", "rj"),
+    ("p", "pj"),
+    ("b", "bj"),
+    ("v", "vj"),
+    ("m", "mj"),
+];
+
+/// Whether a stem counts as soft, driving the O⇒E ending alternation and the
+/// comparative `-ejši`/`-ějši` choice. True when the last character is one of
+/// `š ž č c j ć đ ń ľ ŕ`, or the stem ends in the digraph `lj`, `nj`, or `dž`.
+pub fn is_soft(stem: &str) -> bool {
+    let last = stem.chars().last().unwrap_or(' ');
+    matches!(
+        last,
+        'š' | 'ž' | 'č' | 'c' | 'j' | 'ć' | 'đ' | 'ń' | 'ľ' | 'ŕ'
+    ) || stem.ends_with("lj")
+        || stem.ends_with("nj")
+        || stem.ends_with("dž")
+}
+
+/// Apply first palatalization to a stem-final consonant (no-op if the final
+/// consonant is not one of the palatalization sources).
+pub fn palatalize_final(stem: &str) -> String {
+    let mut s = stem.to_string();
+    if let Some(last) = s.chars().last() {
+        if let Some((_, soft)) = PALATALIZATION.iter().find(|(hard, _)| *hard == last) {
+            s.pop();
+            s.push(*soft);
+        }
+    }
+    s
+}
+
+/// Apply iotation to a stem-final consonant (longest match first); returns the
+/// stem unchanged if nothing matches.
+pub fn iotate_final(stem: &str) -> String {
+    for (suf, rep) in IOTATION {
+        if let Some(head) = stem.strip_suffix(suf) {
+            return format!("{head}{rep}");
+        }
+    }
+    stem.to_string()
+}
+
+/// All possible un-palatalized sources of a stem (always includes the stem
+/// itself, since a hushing-final stem may be original rather than derived).
+pub fn inverse_palatalization(stem: &str) -> Vec<String> {
+    let mut v = vec![stem.to_string()];
+    for (hard, soft) in PALATALIZATION {
+        if let Some(head) = stem.strip_suffix(*soft) {
+            v.push(format!("{head}{hard}"));
+        }
+    }
+    v
+}
+
+/// All possible un-iotated sources of a form (always includes the form itself
+/// so hushing-final stems — učiti → uč- — resolve too). Covers every hard
+/// source of an ambiguous soft outcome (š ← s or h, ž ← z or g, č ← k …).
+pub fn inverse_iotation(t: &str) -> Vec<String> {
+    let mut v = vec![t.to_string()];
+    for (hard, soft) in IOTATION {
+        if let Some(head) = t.strip_suffix(soft) {
+            v.push(format!("{head}{hard}"));
+        }
+    }
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tables_round_trip() {
+        // Every iotation outcome inverts back to its source.
+        for (hard, soft) in IOTATION {
+            let stem = format!("xx{hard}");
+            let iotated = iotate_final(&stem);
+            // Longest-match: a single-char source that lives inside a longer
+            // match (s inside st) iotates as the longer pair; skip those.
+            if iotated == format!("xx{soft}") {
+                assert!(
+                    inverse_iotation(&iotated).contains(&stem),
+                    "{stem} → {iotated} does not invert"
+                );
+            }
+        }
+        for (hard, _) in PALATALIZATION {
+            let stem = format!("xx{hard}");
+            assert!(inverse_palatalization(&palatalize_final(&stem)).contains(&stem));
+        }
+    }
+
+    #[test]
+    fn softness_covers_all_palatal_outcomes() {
+        // Any stem produced by palatalization or iotation must count as soft —
+        // the invariant that keeps the comparative -ejši/-ějši choice correct.
+        for (hard, _) in PALATALIZATION {
+            assert!(is_soft(&palatalize_final(&format!("xx{hard}"))));
+        }
+        for (hard, _) in IOTATION {
+            assert!(is_soft(&iotate_final(&format!("xx{hard}"))));
+        }
+        for s in [
+            "końń", "xxń", "xxľ", "xxŕ", "xxć", "xxđ", "xxlj", "xxnj", "xxdž",
+        ] {
+            assert!(is_soft(s), "{s} must be soft");
+        }
+    }
+}

--- a/crates/interslavic/src/lib.rs
+++ b/crates/interslavic/src/lib.rs
@@ -35,7 +35,7 @@
 
 use interslavic_core::ISVCore;
 pub use interslavic_core::{
-    Animacy, Case, Gender, NounGender, Number, Person, Tense, VerbParadigm,
+    phono, Animacy, Case, Gender, NounGender, Number, Person, Tense, VerbParadigm,
 };
 
 mod dictionary;


### PR DESCRIPTION
Closes #9.

## What

New `crates/interslavic-core/src/phono.rs` — the canonical home for Interslavic morphophonemics:

- `PALATALIZATION` (k→č, g→ž, h→š, c→č) and the 16-pair `IOTATION` table (longest-match-first, etymological `ć`/`đ`/`šć`/`žđ`);
- `is_soft(stem)` — the softness predicate driving the O⇒E alternation and the comparative `-ejši`/`-ějši` choice;
- forward appliers `palatalize_final` / `iotate_final` and programmatically transposed `inverse_palatalization` / `inverse_iotation`.

Exposed as `pub mod phono` from interslavic-core and re-exported from the `interslavic` facade, so consumers reach it as `interslavic::phono::*`.

## Why

This is the shared foundation for **#8 (degrees of comparison)** and **#7 (pronoun/numeral declension)**. Landing it first means those features consume one authoritative table set instead of each re-deriving the correspondences — which is precisely the divergence this consolidation prevents (the downstream Slovowiki project hit a real bug from three drifted private copies; this stops the crate from repeating it).

## Scope (honest note for reviewers)

The crate already has a few older, narrower alternation sites: the velar-only yer-marking used by the `-es-` neuter nouns, and `iotation_merge` (currently unused internally, and it writes the `dž` digraph rather than `đ`). **This PR does not rewire them** — reconciling the `dž`-vs-`đ` convention would perturb the noun/verb declension goldens and is a separate change. This PR is purely additive; new functionality builds on `phono` directly, and the follow-up reconciliation is noted in the module doc.

## Tests

phono ships invariant tests — inverse-table round-trips, and *every palatalization/iotation outcome must register as soft*. Full `cargo test --workspace` green; `cargo clippy --workspace` clean.