### PR TITLE
Add degrees of comparison (ISV::comparative / ISV::superlative)

### DIFF
--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -1068,6 +1068,83 @@ impl ISVCore {
                 .replace("(o)", "")
         }
     }
+
+    /// The synthetic comparative of an adjective, as `(comparative adjective,
+    /// comparative adverb)`.
+    ///
+    /// Returns `None` for adjectives that do not gradate synthetically — the
+    /// relational `-sky`/`-cky` type, forms that already are comparatives or
+    /// participial adjectives (`-ši`/`-ći`), and the soft `-ji` possessives —
+    /// for which the analytic comparative (`vyše`/`bolje` + the positive) is
+    /// used instead. The returned comparative is itself a soft adjective, so
+    /// its full paradigm is `decline_adj(comparative, …)`; the superlative is
+    /// `naj-` prefixed (see [`ISVCore::superlative`]).
+    ///
+    /// Rules: seven lexical irregulars (dobry→lěpši, zly→gorši, …); the
+    /// `-ky`/`-eky`/`-oky` class takes `-ši` on the truncated root with an
+    /// iotated adverb (daleky→dalši/dalje, vysoky→vysši/vyše); otherwise the
+    /// seam is palatalized and the softness of the result picks `-ějši`/`-ěje`
+    /// (hard) vs `-ejši`/`-eje` (soft), e.g. novy→novějši, blagy stays
+    /// irregular, ryđi→ryđejši.
+    pub fn comparative(adj: &str) -> Option<(String, String)> {
+        // Non-gradable: relational -sky/-cky, already-comparative/participial
+        // -ši/-ći, and soft -ji possessives (ji+ejši would be malformed).
+        if adj.ends_with("sky")
+            || adj.ends_with("cky")
+            || adj.ends_with("ši")
+            || adj.ends_with("ći")
+            || adj.ends_with("ji")
+        {
+            return None;
+        }
+        // Seven lexical irregulars, matched on the full lemma.
+        for (base, comp, adv) in [
+            ("dobry", "lěpši", "lěpje"),
+            ("zly", "gorši", "gorje"),
+            ("veliky", "večši", "veče"),
+            ("maly", "menši", "menje"),
+            ("blagy", "unši", "unje"),
+            ("legky", "legši", "legše"),
+            ("mękky", "mękši", "mękše"),
+        ] {
+            if adj == base {
+                return Some((comp.to_string(), adv.to_string()));
+            }
+        }
+        let stem = adj.strip_suffix(['y', 'i'])?;
+        if stem.chars().count() < 2 {
+            return None;
+        }
+        // -ky / -eky / -oky class: -ši on the truncated root, adverb by
+        // iotation. Roots shorter than 3 chars (diky → *di-) fall through to
+        // the regular rule instead of producing a degenerate stem.
+        for suf in ["ok", "ek", "k"] {
+            if let Some(root) = stem.strip_suffix(suf) {
+                if root.chars().count() >= 3 {
+                    let comp = format!("{root}ši");
+                    let adv = format!("{}e", crate::phono::iotate_final(root));
+                    return Some((comp, adv));
+                }
+                break;
+            }
+        }
+        // Regular: palatalize the seam, then the full softness predicate picks
+        // the soft (-ejši) vs hard (-ějši) ending.
+        let pal = crate::phono::palatalize_final(stem);
+        let (adj_suf, adv_suf) = if crate::phono::is_soft(&pal) {
+            ("ejši", "eje")
+        } else {
+            ("ějši", "ěje")
+        };
+        Some((format!("{pal}{adj_suf}"), format!("{pal}{adv_suf}")))
+    }
+
+    /// The synthetic superlative of an adjective, as `(superlative adjective,
+    /// superlative adverb)` — the [`ISVCore::comparative`] with the `naj-`
+    /// prefix. `None` when the adjective does not gradate synthetically.
+    pub fn superlative(adj: &str) -> Option<(String, String)> {
+        ISVCore::comparative(adj).map(|(c, a)| (format!("naj{c}"), format!("naj{a}")))
+    }
 }
 
 //NOUN STUFF

--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -1086,6 +1086,12 @@ impl ISVCore {
     /// seam is palatalized and the softness of the result picks `-ějši`/`-ěje`
     /// (hard) vs `-ejši`/`-eje` (soft), e.g. novy→novějši, blagy stays
     /// irregular, ryđi→ryđejši.
+    ///
+    /// Precondition: `adj` is a positive-degree qualitative adjective written
+    /// in the flavored (etymological) orthography; the result is unspecified
+    /// for other input (a verb infinitive also ends in `-i` and would gradate
+    /// spuriously). Determiners and other non-gradable words should not be
+    /// passed here.
     pub fn comparative(adj: &str) -> Option<(String, String)> {
         // Non-gradable: relational -sky/-cky, already-comparative/participial
         // -ši/-ći, and soft -ji possessives (ji+ejši would be malformed).
@@ -1115,17 +1121,25 @@ impl ISVCore {
         if stem.chars().count() < 2 {
             return None;
         }
-        // -ky / -eky / -oky class: -ši on the truncated root, adverb by
-        // iotation. Roots shorter than 3 chars (diky → *di-) fall through to
-        // the regular rule instead of producing a degenerate stem.
-        for suf in ["ok", "ek", "k"] {
-            if let Some(root) = stem.strip_suffix(suf) {
-                if root.chars().count() >= 3 {
-                    let comp = format!("{root}ši");
-                    let adv = format!("{}e", crate::phono::iotate_final(root));
-                    return Some((comp, adv));
+        // -ky / -eky / -oky class: -ši on the truncated root (kratky→kratši,
+        // vysoky→vysši, uzky→uzši), adverb by iotation of the root
+        // (kratky→kraće, vysoky→vyše, uzky→uže). A few adjectives end in -ky
+        // with the k belonging to the ROOT rather than the -ky suffix; they
+        // palatalize regularly instead (diky→dičejši, not *diši), so they are
+        // excluded here and fall through to the regular rule below. (Root
+        // length cannot tell them apart — both diky and uzky leave a 2-char
+        // root — so the distinction is lexical.)
+        const ROOT_FINAL_K: &[&str] = &["diky"];
+        if !ROOT_FINAL_K.contains(&adj) {
+            for suf in ["ok", "ek", "k"] {
+                if let Some(root) = stem.strip_suffix(suf) {
+                    if root.chars().count() >= 2 {
+                        let comp = format!("{root}ši");
+                        let adv = format!("{}e", crate::phono::iotate_final(root));
+                        return Some((comp, adv));
+                    }
+                    break;
                 }
-                break;
             }
         }
         // Regular: palatalize the seam, then the full softness predicate picks

--- a/crates/interslavic/src/lib.rs
+++ b/crates/interslavic/src/lib.rs
@@ -86,6 +86,35 @@ impl ISV {
         ISVCore::decline_adj(word, &case, &number, &gender, animacy)
     }
 
+    /// The synthetic comparative of an adjective, as `(comparative adjective,
+    /// comparative adverb)`. `None` for adjectives that do not gradate
+    /// synthetically (relational `-sky`/`-cky`, already-comparative `-ši`/`-ći`,
+    /// soft `-ji` possessives) — use the analytic comparative (`vyše`/`bolje`
+    /// followed by the positive) there. The comparative is a soft adjective,
+    /// so its paradigm is `ISV::adj(comparative, …)`.
+    ///
+    /// ```
+    /// use interslavic::ISV;
+    /// assert_eq!(ISV::comparative("novy"), Some(("novějši".into(), "nověje".into())));
+    /// assert_eq!(ISV::comparative("dobry"), Some(("lěpši".into(), "lěpje".into())));
+    /// assert_eq!(ISV::comparative("russky"), None);
+    /// ```
+    pub fn comparative(adj: &str) -> Option<(String, String)> {
+        ISVCore::comparative(adj.trim())
+    }
+
+    /// The synthetic superlative of an adjective, as `(superlative adjective,
+    /// superlative adverb)` — the comparative with the `naj-` prefix. `None`
+    /// when the adjective does not gradate synthetically.
+    ///
+    /// ```
+    /// use interslavic::ISV;
+    /// assert_eq!(ISV::superlative("novy"), Some(("najnovějši".into(), "najnověje".into())));
+    /// ```
+    pub fn superlative(adj: &str) -> Option<(String, String)> {
+        ISVCore::superlative(adj.trim())
+    }
+
     /// One finite verb form. Present, imperfect, future, perfect, pluperfect,
     /// and conditional are supported; imperative and participial/gerund forms
     /// are available through `verb_forms`.

--- a/crates/interslavic/src/lib.rs
+++ b/crates/interslavic/src/lib.rs
@@ -91,7 +91,9 @@ impl ISV {
     /// synthetically (relational `-sky`/`-cky`, already-comparative `-ši`/`-ći`,
     /// soft `-ji` possessives) — use the analytic comparative (`vyše`/`bolje`
     /// followed by the positive) there. The comparative is a soft adjective,
-    /// so its paradigm is `ISV::adj(comparative, …)`.
+    /// so its paradigm is `ISV::adj(comparative, …)`. Expects a positive-degree
+    /// qualitative adjective in flavored orthography; other input (verbs,
+    /// determiners) is unspecified.
     ///
     /// ```
     /// use interslavic::ISV;

--- a/crates/interslavic/tests/comparison.rs
+++ b/crates/interslavic/tests/comparison.rs
@@ -19,7 +19,11 @@ fn comparatives_follow_steen() {
     assert_eq!(comp("žestoky"), Some(("žestši".into(), "žešće".into()))); // st → šć
                                                                           // Soft đ-final stem takes -ejši, not hard -ějši.
     assert_eq!(comp("ryđi"), Some(("ryđejši".into(), "ryđeje".into())));
-    // Short k-root falls through to the regular rule (not a degenerate *diši).
+    // Short-root -ky truncators (2-char root) still truncate, not palatalize:
+    // the -ky is the suffix here, so drop it (uz-, niz-) rather than uzč-.
+    assert_eq!(comp("uzky"), Some(("uzši".into(), "uže".into())));
+    assert_eq!(comp("nizky"), Some(("nizši".into(), "niže".into())));
+    // But diky's k is root-final, so it palatalizes regularly (not *diši).
     assert_eq!(comp("diky"), Some(("dičejši".into(), "dičeje".into())));
 }
 

--- a/crates/interslavic/tests/comparison.rs
+++ b/crates/interslavic/tests/comparison.rs
@@ -1,0 +1,52 @@
+use interslavic::*;
+
+fn comp(adj: &str) -> Option<(String, String)> {
+    ISV::comparative(adj)
+}
+
+#[test]
+fn comparatives_follow_steen() {
+    // Regular hard stem.
+    assert_eq!(comp("novy"), Some(("novějši".into(), "nověje".into())));
+    // Lexical irregulars.
+    assert_eq!(comp("blagy"), Some(("unši".into(), "unje".into())));
+    assert_eq!(comp("dobry"), Some(("lěpši".into(), "lěpje".into())));
+    // -ky class: -ši on the truncated root, adverb by iotation.
+    assert_eq!(comp("kratky"), Some(("kratši".into(), "kraće".into())));
+    assert_eq!(comp("vysoky"), Some(("vysši".into(), "vyše".into())));
+    assert_eq!(comp("glųboky"), Some(("glųbši".into(), "glųbje".into()))); // labial → j
+    assert_eq!(comp("krěhky"), Some(("krěhši".into(), "krěše".into()))); // h → š
+    assert_eq!(comp("žestoky"), Some(("žestši".into(), "žešće".into()))); // st → šć
+                                                                          // Soft đ-final stem takes -ejši, not hard -ějši.
+    assert_eq!(comp("ryđi"), Some(("ryđejši".into(), "ryđeje".into())));
+    // Short k-root falls through to the regular rule (not a degenerate *diši).
+    assert_eq!(comp("diky"), Some(("dičejši".into(), "dičeje".into())));
+}
+
+#[test]
+fn non_gradable_adjectives_return_none() {
+    for a in [
+        "russky",    // relational -sky
+        "gręcky",    // relational -cky
+        "bogatši",   // already a comparative
+        "bųdųći",    // participial -ći
+        "boljši",    // already a comparative
+        "božji",     // soft -ji possessive
+        "poslědnji", // soft -nji
+    ] {
+        assert_eq!(comp(a), None, "{a} must not gradate synthetically");
+    }
+}
+
+#[test]
+fn superlative_prefixes_naj() {
+    assert_eq!(
+        ISV::superlative("novy"),
+        Some(("najnovějši".into(), "najnověje".into()))
+    );
+    assert_eq!(
+        ISV::superlative("dobry"),
+        Some(("najlěpši".into(), "najlěpje".into()))
+    );
+    assert_eq!(ISV::superlative("russky"), None);
+}


### PR DESCRIPTION
Closes #8. Builds on #9 (phono).

## What

- `ISVCore::comparative(adj) -> Option<(String, String)>` — the synthetic `(comparative adjective, comparative adverb)`, faced by `ISV::comparative`.
- `ISV::superlative` — the same pair with the `naj-` prefix.

Both consume the `phono` module: the seam is palatalized and the softness of the result picks `-ejši`/`-eje` (soft) vs `-ějši`/`-ěje` (hard).

## Rules

- Seven lexical irregulars (`dobry→lěpši/lěpje`, `zly→gorši`, `veliky→večši`, `maly→menši`, `blagy→unši`, `legky→legši`, `mękky→mękši`).
- The `-ky/-eky/-oky` class takes `-ši` on the truncated root with an **iotated adverb** (`vysoky→vysši/vyše`, `glųboky→glųbši/glųbje` labial→j, `krěhky→krěše` h→š, `žestoky→žešće` st→šć); short k-roots fall through to the regular rule (`diky→dičejši`, not a degenerate `*diši`).
- Otherwise regular `-ějši`/`-ejši`.

## The non-gradable guard (the part that matters)

`None` is returned for adjectives that do not gradate synthetically — relational `-sky`/`-cky`, forms that already are comparatives or participials (`-ši`/`-ći`), and soft `-ji` possessives — where the analytic `vyše`/`bolje` + positive is used instead. This guard encodes the linguistic knowledge that stops a consumer from emitting garbage degrees like `*russši` or `*božjejši` (a mistake the downstream project shipped and had to purge before this guard existed).

The returned comparative is itself a soft adjective, so its full paradigm is `ISV::adj(comparative, …)`.

## Tests

Golden comparatives ported from the downstream project's verified set (`comparison.rs`), a non-gradable guard test, a superlative test, and doctests on both facade methods. `cargo test --workspace` green (incl. doctests); `cargo clippy --workspace` clean.