### PR TITLE
Add pronoun & numeral declension (ISV::pronoun / ISV::numeral)

### DIFF
--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -1194,6 +1194,11 @@ impl ISVCore {
     /// their derivatives, the internally-inflecting `-koli` indefinites,
     /// `veś`, and the adjectivally-declined determiners (`ktory`, `kaky`,
     /// `samy`, …).
+    ///
+    /// Recognition is by word SHAPE, not a closed lexicon: the last-resort
+    /// branch declines any `-y`/`-i` word as an adjective, so a same-shaped
+    /// non-pronoun yields a (correctly-declined) `Some` rather than `None`.
+    /// Lemmas are the flavored (etymological) citation forms.
     pub fn decline_pronoun(
         lemma: &str,
         case: &Case,
@@ -1205,12 +1210,21 @@ impl ISVCore {
         if l.is_empty() || l.contains(' ') {
             return None;
         }
-        // -koli indefinites inflect internally: decline the head, re-append.
-        if let Some(head) = l.strip_suffix("koli") {
-            if !head.is_empty() {
-                return ISVCore::decline_pronoun(head, case, number, gender, animacy)
-                    .map(|f| format!("{f}koli"));
+        // -koli indefinites inflect internally on the head, then re-append the
+        // particle. Strip iteratively (not recursively) so a pathological
+        // "kolikoli…" input cannot overflow the stack.
+        let mut head = l;
+        let mut koli = 0usize;
+        while let Some(rest) = head.strip_suffix("koli") {
+            if rest.is_empty() {
+                break;
             }
+            head = rest;
+            koli += 1;
+        }
+        if koli > 0 {
+            return ISVCore::decline_pronoun(head, case, number, gender, animacy)
+                .map(|f| format!("{f}{}", "koli".repeat(koli)));
         }
         // toj-class demonstratives: hard pronominal declension.
         if matches!(l, "toj" | "tutoj" | "tamtoj" | "onoj" | "ov") {
@@ -1246,9 +1260,14 @@ impl ISVCore {
                 "vsi", l, case, number, gender, animacy,
             ));
         }
-        // moj-class possessives/interrogatives (incl. ni-/ně-/vse- derived):
-        // soft pronominal declension over the full lemma.
-        if (l.ends_with("oj") && l != "obydvoj") || l.ends_with("čij") || l == "naš" || l == "vaš"
+        // moj-class possessives/interrogatives (moj, tvoj, svoj, koj, čij, naš,
+        // vaš, and their ni-/ně-/vse- prefixed derivatives): soft pronominal
+        // declension over the full lemma. The length guard excludes the bare
+        // conjunction "oj".
+        if (l.ends_with("oj") && l.chars().count() >= 3)
+            || l.ends_with("čij")
+            || l == "naš"
+            || l == "vaš"
         {
             let synthetic = format!("{l}i");
             return Some(ISVCore::pronominal_via_adj(
@@ -1268,6 +1287,12 @@ impl ISVCore {
     /// numerals `pęť`…`desęť` (declining like `kosť`), and the adjectivally-
     /// declined ordinals (`pŕvy`, `drugy`, …). Cardinals return their citation
     /// form for nominative/accusative.
+    ///
+    /// Recognition is by word SHAPE (an i-stem lemma is detected by its final
+    /// `-ť`, an ordinal by its `-y`/`-i`), not a closed lexicon, so a same-
+    /// shaped non-numeral — a feminine i-stem noun like `kosť` — yields a
+    /// (correctly-declined) `Some`. Lemmas are the flavored citation forms
+    /// (`desęť`, not `deset`).
     pub fn decline_numeral(
         lemma: &str,
         case: &Case,

--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -1159,6 +1159,177 @@ impl ISVCore {
     pub fn superlative(adj: &str) -> Option<(String, String)> {
         ISVCore::comparative(adj).map(|(c, a)| (format!("naj{c}"), format!("naj{a}")))
     }
+
+    /// The pronominal (hard `toj` / soft `moj`) declension of a synthetic
+    /// adjective lemma, with the masculine nominative singular — and the
+    /// masculine inanimate accusative singular, which is syncretic with it —
+    /// overridden to the pronoun's actual nominative.
+    ///
+    /// The oblique cells of the pronominal declension are identical to the
+    /// adjectival ones (togo≡the gen.sg of hard `ty`, mojego≡the gen.sg of
+    /// soft `moji`), so `decline_adj` on a synthetic `stem+y`/`stem+i` lemma
+    /// produces them; only the two nominative-syncretic masculine cells
+    /// differ (a pronoun has `toj`, not `*ty`).
+    fn pronominal_via_adj(
+        synthetic: &str,
+        nom_masc: &str,
+        case: &Case,
+        number: &Number,
+        gender: &Gender,
+        animacy: Animacy,
+    ) -> String {
+        let is_masc_nom_sg = *gender == Gender::Masculine
+            && *number == Number::Singular
+            && (*case == Case::Nom || (*case == Case::Acc && animacy == Animacy::Inanimate));
+        if is_masc_nom_sg {
+            nom_masc.to_string()
+        } else {
+            ISVCore::decline_adj(synthetic, case, number, gender, animacy)
+        }
+    }
+
+    /// One pronoun form, or `None` if `lemma` is not a recognized pronoun
+    /// paradigm. Covers the `toj`-class demonstratives, the `moj`-class
+    /// possessives/interrogatives (incl. `naš`/`vaš`/`čij`), `kto`/`čto` and
+    /// their derivatives, the internally-inflecting `-koli` indefinites,
+    /// `veś`, and the adjectivally-declined determiners (`ktory`, `kaky`,
+    /// `samy`, …).
+    pub fn decline_pronoun(
+        lemma: &str,
+        case: &Case,
+        number: &Number,
+        gender: &Gender,
+        animacy: Animacy,
+    ) -> Option<String> {
+        let l = lemma.trim();
+        if l.is_empty() || l.contains(' ') {
+            return None;
+        }
+        // -koli indefinites inflect internally: decline the head, re-append.
+        if let Some(head) = l.strip_suffix("koli") {
+            if !head.is_empty() {
+                return ISVCore::decline_pronoun(head, case, number, gender, animacy)
+                    .map(|f| format!("{f}koli"));
+            }
+        }
+        // toj-class demonstratives: hard pronominal declension.
+        if matches!(l, "toj" | "tutoj" | "tamtoj" | "onoj" | "ov") {
+            let stem = l.strip_suffix("oj").unwrap_or(l);
+            let synthetic = format!("{stem}y");
+            return Some(ISVCore::pronominal_via_adj(
+                &synthetic, l, case, number, gender, animacy,
+            ));
+        }
+        // kto and its derivatives (nikto, něstokto, vsekto, …).
+        if let Some(head) = l.strip_suffix("kto") {
+            return Some(match case {
+                Case::Nom => l.to_string(),
+                Case::Gen | Case::Acc => format!("{head}kogo"),
+                Case::Dat => format!("{head}komu"),
+                Case::Ins => format!("{head}kym"),
+                Case::Loc => format!("{head}kom"),
+            });
+        }
+        // čto / što and derivatives (inanimate: accusative = nominative).
+        if let Some(head) = l.strip_suffix("čto").or_else(|| l.strip_suffix("što")) {
+            return Some(match case {
+                Case::Nom | Case::Acc => l.to_string(),
+                Case::Gen => format!("{head}čego"),
+                Case::Dat => format!("{head}čemu"),
+                Case::Ins => format!("{head}čim"),
+                Case::Loc => format!("{head}čem"),
+            });
+        }
+        // veś "all, whole": soft pronominal declension over the vs- stem.
+        if l == "veś" || l == "ves" {
+            return Some(ISVCore::pronominal_via_adj(
+                "vsi", l, case, number, gender, animacy,
+            ));
+        }
+        // moj-class possessives/interrogatives (incl. ni-/ně-/vse- derived):
+        // soft pronominal declension over the full lemma.
+        if (l.ends_with("oj") && l != "obydvoj") || l.ends_with("čij") || l == "naš" || l == "vaš"
+        {
+            let synthetic = format!("{l}i");
+            return Some(ISVCore::pronominal_via_adj(
+                &synthetic, l, case, number, gender, animacy,
+            ));
+        }
+        // Adjectivally-declined determiners (ktory, kaky, samy, vsaky, iny…).
+        if l.ends_with(['y', 'i']) && l.chars().count() >= 3 {
+            return Some(ISVCore::decline_adj(l, case, number, gender, animacy));
+        }
+        None
+    }
+
+    /// One numeral form, or `None` if `lemma` is not a recognized numeral.
+    /// Covers `jedin` (adjectival, with the irregular masculine nominative),
+    /// the dual-remnant `dva`/`oba`/`obydva` and `tri`/`četyri`, the i-stem
+    /// numerals `pęť`…`desęť` (declining like `kosť`), and the adjectivally-
+    /// declined ordinals (`pŕvy`, `drugy`, …). Cardinals return their citation
+    /// form for nominative/accusative.
+    pub fn decline_numeral(
+        lemma: &str,
+        case: &Case,
+        number: &Number,
+        gender: &Gender,
+        animacy: Animacy,
+    ) -> Option<String> {
+        let l = lemma.trim();
+        if l.is_empty() || l.contains(' ') {
+            return None;
+        }
+        // jedin: declines like the hard adjective *jedny, except the masculine
+        // nominative singular is the irregular citation form jedin.
+        if l == "jedin" {
+            return Some(ISVCore::pronominal_via_adj(
+                "jedny", "jedin", case, number, gender, animacy,
+            ));
+        }
+        // Dual remnants 2 (gender only in nom/acc), oba/obydva likewise.
+        for (base, stem) in [("dva", "dv"), ("oba", "ob"), ("obydva", "obydv")] {
+            if l == base {
+                return Some(match case {
+                    Case::Nom | Case::Acc => {
+                        if *gender == Gender::Feminine {
+                            format!("{stem}ě")
+                        } else {
+                            l.to_string()
+                        }
+                    }
+                    Case::Gen | Case::Loc => format!("{stem}oh"),
+                    Case::Dat => format!("{stem}om"),
+                    Case::Ins => format!("{stem}oma"),
+                });
+            }
+        }
+        // 3 and 4: dual-remnant declension, no gender.
+        if l == "tri" || l == "četyri" {
+            let stem = l.strip_suffix('i').unwrap_or(l);
+            return Some(match case {
+                Case::Nom | Case::Acc => l.to_string(),
+                Case::Gen | Case::Loc => format!("{stem}ěh"),
+                Case::Dat => format!("{stem}ěm"),
+                Case::Ins => format!("{stem}ěmi"),
+            });
+        }
+        // 5 and up (pęť…desęť and the -nadsęť/-deset series): the i-stem
+        // (kosť-class) declension.
+        if let Some(stem) = l.strip_suffix('ť') {
+            if stem.chars().count() >= 2 {
+                return Some(match case {
+                    Case::Nom | Case::Acc => l.to_string(),
+                    Case::Gen | Case::Dat | Case::Loc => format!("{stem}ti"),
+                    Case::Ins => format!("{l}jų"),
+                });
+            }
+        }
+        // Ordinals and other adjectivally-shaped numerals (pŕvy, drugy…).
+        if l.ends_with(['y', 'i']) && l.chars().count() >= 3 {
+            return Some(ISVCore::decline_adj(l, case, number, gender, animacy));
+        }
+        None
+    }
 }
 
 //NOUN STUFF

--- a/crates/interslavic/src/lib.rs
+++ b/crates/interslavic/src/lib.rs
@@ -117,6 +117,51 @@ impl ISV {
         ISVCore::superlative(adj.trim())
     }
 
+    /// One pronoun form, or `None` if the lemma is not a recognized pronoun.
+    /// Covers the `toj`-class demonstratives, the `moj`-class possessives and
+    /// interrogatives (incl. `naš`/`vaš`/`čij`), `kto`/`čto` and derivatives,
+    /// the `-koli` indefinites, `veś`, and the adjectivally-declined
+    /// determiners (`ktory`, `kaky`, `samy`, …).
+    ///
+    /// ```
+    /// use interslavic::*;
+    /// assert_eq!(ISV::pronoun("toj", Case::Gen, Number::Singular, Gender::Masculine, Animacy::Inanimate), Some("togo".into()));
+    /// assert_eq!(ISV::pronoun("moj", Case::Dat, Number::Singular, Gender::Neuter, Animacy::Inanimate), Some("mojemu".into()));
+    /// assert_eq!(ISV::pronoun("kto", Case::Gen, Number::Singular, Gender::Masculine, Animacy::Animate), Some("kogo".into()));
+    /// assert_eq!(ISV::pronoun("stol", Case::Gen, Number::Singular, Gender::Masculine, Animacy::Inanimate), None);
+    /// ```
+    pub fn pronoun(
+        lemma: &str,
+        case: Case,
+        number: Number,
+        gender: Gender,
+        animacy: Animacy,
+    ) -> Option<String> {
+        ISVCore::decline_pronoun(lemma.trim(), &case, &number, &gender, animacy)
+    }
+
+    /// One numeral form, or `None` if the lemma is not a recognized numeral.
+    /// Covers `jedin`, the dual-remnant `dva`/`oba`/`obydva` and `tri`/`četyri`,
+    /// the i-stem numerals `pęť`…`desęť`, and the adjectivally-declined ordinals
+    /// (`pŕvy`, `drugy`, …). Cardinals return their citation form for the
+    /// nominative and accusative.
+    ///
+    /// ```
+    /// use interslavic::*;
+    /// assert_eq!(ISV::numeral("pęť", Case::Gen, Number::Plural, Gender::Masculine, Animacy::Inanimate), Some("pęti".into()));
+    /// assert_eq!(ISV::numeral("tri", Case::Gen, Number::Plural, Gender::Masculine, Animacy::Inanimate), Some("trěh".into()));
+    /// assert_eq!(ISV::numeral("pŕvy", Case::Gen, Number::Singular, Gender::Masculine, Animacy::Inanimate), Some("pŕvogo".into()));
+    /// ```
+    pub fn numeral(
+        lemma: &str,
+        case: Case,
+        number: Number,
+        gender: Gender,
+        animacy: Animacy,
+    ) -> Option<String> {
+        ISVCore::decline_numeral(lemma.trim(), &case, &number, &gender, animacy)
+    }
+
     /// One finite verb form. Present, imperfect, future, perfect, pluperfect,
     /// and conditional are supported; imperative and participial/gerund forms
     /// are available through `verb_forms`.

--- a/crates/interslavic/tests/pronoun_numeral.rs
+++ b/crates/interslavic/tests/pronoun_numeral.rs
@@ -1,0 +1,383 @@
+use interslavic::*;
+
+fn pron(l: &str, c: Case, n: Number, g: Gender, a: Animacy) -> Option<String> {
+    ISV::pronoun(l, c, n, g, a)
+}
+fn num(l: &str, c: Case, n: Number, g: Gender, a: Animacy) -> Option<String> {
+    ISV::numeral(l, c, n, g, a)
+}
+
+// Shorthands for the common masc-inanimate singular query.
+fn ms(l: &str, c: Case) -> Option<String> {
+    ISV::pronoun(
+        l,
+        c,
+        Number::Singular,
+        Gender::Masculine,
+        Animacy::Inanimate,
+    )
+}
+
+#[test]
+fn toj_class_hard_pronominal() {
+    // Masculine singular: the citation form is the nominative (and the
+    // syncretic inanimate accusative); obliques are the hard pronominal set.
+    assert_eq!(ms("toj", Case::Nom), Some("toj".into()));
+    assert_eq!(ms("toj", Case::Acc), Some("toj".into())); // inanimate acc = nom
+    assert_eq!(ms("toj", Case::Gen), Some("togo".into()));
+    assert_eq!(ms("toj", Case::Dat), Some("tomu".into()));
+    assert_eq!(ms("toj", Case::Loc), Some("tom".into()));
+    assert_eq!(ms("toj", Case::Ins), Some("tym".into()));
+    // Masculine animate accusative = genitive.
+    assert_eq!(
+        pron(
+            "toj",
+            Case::Acc,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Animate
+        ),
+        Some("togo".into())
+    );
+    // Feminine / neuter singular.
+    assert_eq!(
+        pron(
+            "toj",
+            Case::Nom,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+        Some("ta".into())
+    );
+    assert_eq!(
+        pron(
+            "toj",
+            Case::Acc,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+        Some("tų".into())
+    );
+    assert_eq!(
+        pron(
+            "toj",
+            Case::Ins,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+        Some("tojų".into())
+    );
+    assert_eq!(
+        pron(
+            "toj",
+            Case::Nom,
+            Number::Singular,
+            Gender::Neuter,
+            Animacy::Inanimate
+        ),
+        Some("to".into())
+    );
+    // Plural.
+    assert_eq!(
+        pron(
+            "toj",
+            Case::Nom,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Animate
+        ),
+        Some("ti".into())
+    );
+    assert_eq!(ms("toj", Case::Gen).map(|_| ()), Some(())); // (gen.sg checked above)
+    assert_eq!(
+        pron(
+            "toj",
+            Case::Gen,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("tyh".into())
+    );
+    assert_eq!(
+        pron(
+            "toj",
+            Case::Ins,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("tymi".into())
+    );
+    // ov declines like toj (stem = whole lemma).
+    assert_eq!(ms("ov", Case::Gen), Some("ovogo".into()));
+    assert_eq!(ms("ov", Case::Nom), Some("ov".into()));
+}
+
+#[test]
+fn moj_class_soft_pronominal() {
+    assert_eq!(ms("moj", Case::Nom), Some("moj".into()));
+    assert_eq!(ms("moj", Case::Gen), Some("mojego".into()));
+    assert_eq!(ms("moj", Case::Dat), Some("mojemu".into()));
+    assert_eq!(ms("moj", Case::Ins), Some("mojim".into()));
+    assert_eq!(
+        pron(
+            "moj",
+            Case::Acc,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+        Some("mojų".into())
+    );
+    assert_eq!(
+        pron(
+            "moj",
+            Case::Ins,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+        Some("mojejų".into())
+    );
+    // naš / vaš / čij follow the same soft pattern.
+    assert_eq!(ms("naš", Case::Gen), Some("našego".into()));
+    assert_eq!(ms("naš", Case::Nom), Some("naš".into()));
+    assert_eq!(ms("čij", Case::Gen), Some("čijego".into()));
+}
+
+#[test]
+fn ves_soft_pronominal() {
+    assert_eq!(ms("veś", Case::Nom), Some("veś".into()));
+    assert_eq!(ms("veś", Case::Gen), Some("vsego".into()));
+    assert_eq!(
+        pron(
+            "veś",
+            Case::Nom,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+        Some("vsa".into())
+    );
+    assert_eq!(
+        pron(
+            "veś",
+            Case::Nom,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Animate
+        ),
+        Some("vsi".into())
+    );
+}
+
+#[test]
+fn kto_cto_and_koli() {
+    // kto (animate): accusative = genitive = kogo.
+    assert_eq!(ms("kto", Case::Nom), Some("kto".into()));
+    assert_eq!(ms("kto", Case::Gen), Some("kogo".into()));
+    assert_eq!(ms("kto", Case::Acc), Some("kogo".into()));
+    assert_eq!(ms("kto", Case::Dat), Some("komu".into()));
+    assert_eq!(ms("kto", Case::Ins), Some("kym".into()));
+    assert_eq!(ms("kto", Case::Loc), Some("kom".into()));
+    // čto (inanimate): accusative = nominative = čto.
+    assert_eq!(ms("čto", Case::Nom), Some("čto".into()));
+    assert_eq!(ms("čto", Case::Acc), Some("čto".into()));
+    assert_eq!(ms("čto", Case::Gen), Some("čego".into()));
+    // Derivatives inflect on the kto/čto tail.
+    assert_eq!(ms("nikto", Case::Gen), Some("nikogo".into()));
+    // -koli indefinites inflect internally.
+    assert_eq!(ms("ktokoli", Case::Gen), Some("kogokoli".into()));
+    assert_eq!(ms("ktokoli", Case::Nom), Some("ktokoli".into()));
+}
+
+#[test]
+fn adjectival_determiners() {
+    // ktory / kaky decline as ordinary adjectives (masc nom = citation).
+    assert_eq!(ms("ktory", Case::Nom), Some("ktory".into()));
+    assert_eq!(ms("ktory", Case::Gen), Some("ktorogo".into()));
+    assert_eq!(ms("kaky", Case::Gen), Some("kakogo".into()));
+}
+
+#[test]
+fn jedin_and_cardinals() {
+    // jedin: adjectival, irregular masculine nominative.
+    assert_eq!(
+        num(
+            "jedin",
+            Case::Nom,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("jedin".into())
+    );
+    assert_eq!(
+        num(
+            "jedin",
+            Case::Gen,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("jednogo".into())
+    );
+    assert_eq!(
+        num(
+            "jedin",
+            Case::Nom,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+        Some("jedna".into())
+    );
+    // dva: gender only in nom/acc.
+    assert_eq!(
+        num(
+            "dva",
+            Case::Nom,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("dva".into())
+    );
+    assert_eq!(
+        num(
+            "dva",
+            Case::Nom,
+            Number::Plural,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+        Some("dvě".into())
+    );
+    assert_eq!(
+        num(
+            "dva",
+            Case::Gen,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("dvoh".into())
+    );
+    assert_eq!(
+        num(
+            "dva",
+            Case::Ins,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("dvoma".into())
+    );
+    // tri / četyri.
+    assert_eq!(
+        num(
+            "tri",
+            Case::Gen,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("trěh".into())
+    );
+    assert_eq!(
+        num(
+            "tri",
+            Case::Dat,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("trěm".into())
+    );
+    assert_eq!(
+        num(
+            "tri",
+            Case::Ins,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("trěmi".into())
+    );
+}
+
+#[test]
+fn i_stem_numerals_and_ordinals() {
+    // pęť declines like kosť.
+    assert_eq!(
+        num(
+            "pęť",
+            Case::Nom,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("pęť".into())
+    );
+    assert_eq!(
+        num(
+            "pęť",
+            Case::Gen,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("pęti".into())
+    );
+    assert_eq!(
+        num(
+            "pęť",
+            Case::Ins,
+            Number::Plural,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("pęťjų".into())
+    );
+    // Ordinals decline as adjectives.
+    assert_eq!(
+        num(
+            "pŕvy",
+            Case::Gen,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("pŕvogo".into())
+    );
+    assert_eq!(
+        num(
+            "drugy",
+            Case::Dat,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        Some("drugomu".into())
+    );
+}
+
+#[test]
+fn unrecognized_lemmas_return_none() {
+    assert_eq!(ms("stol", Case::Gen), None);
+    assert_eq!(ms("", Case::Gen), None);
+    assert_eq!(
+        num(
+            "stol",
+            Case::Gen,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        None
+    );
+}

--- a/crates/interslavic/tests/pronoun_numeral.rs
+++ b/crates/interslavic/tests/pronoun_numeral.rs
@@ -91,7 +91,6 @@ fn toj_class_hard_pronominal() {
         ),
         Some("ti".into())
     );
-    assert_eq!(ms("toj", Case::Gen).map(|_| ()), Some(())); // (gen.sg checked above)
     assert_eq!(
         pron(
             "toj",
@@ -370,6 +369,7 @@ fn i_stem_numerals_and_ordinals() {
 fn unrecognized_lemmas_return_none() {
     assert_eq!(ms("stol", Case::Gen), None);
     assert_eq!(ms("", Case::Gen), None);
+    assert_eq!(ms("oj", Case::Gen), None); // bare conjunction, below the -oj guard
     assert_eq!(
         num(
             "stol",


### PR DESCRIPTION
Closes #7. Builds on #9 (phono, indirectly via decline_adj reuse).

## What

- `ISV::pronoun(lemma, case, number, gender, animacy) -> Option<String>`
- `ISV::numeral(lemma, case, number, gender, animacy) -> Option<String>`

`None` means the lemma is not a recognized closed-class pronoun/numeral, so callers can distinguish it from a real form.

## Design: reuse `decline_adj`, don't re-port ending tables

The pronominal declension (hard `toj` / soft `moj`) **is** the adjectival declension — `togo` is the gen.sg of hard `ty`, `mojego` the gen.sg of soft `moji` — verified by probing `decline_adj` across the full paradigm. So both classes reuse the crate's tested `decline_adj` on a synthetic `stem+y`/`stem+i` lemma, and only the two nominative-syncretic masculine cells (masc.nom.sg and masc.inanim.acc.sg, where a pronoun has `toj` not `*ty`) are overridden to the citation form. Pronouns therefore stay consistent with the adjective paradigm automatically.

## Coverage

- **toj-class** demonstratives (`toj`/`tutoj`/`tamtoj`/`onoj`/`ov`) — hard pronominal.
- **moj-class** possessives/interrogatives (`naš`/`vaš`/`čij` + `ni-`/`ně-`/`vse-` derivatives) — soft pronominal; **veś** likewise over the `vs-` stem.
- **kto/čto** + derivatives (`nikto`…) via small direct oblique tables (`kto` animate: acc=gen=`kogo`; `čto` inanimate: acc=nom); **-koli** indefinites inflect internally (`kogokoli`).
- **adjectival determiners** (`ktory`, `kaky`, `samy`…) via `decline_adj`.
- **numerals**: `jedin` (adjectival, irregular masc nom), dual-remnant `dva`/`oba`/`obydva` and `tri`/`četyri`, i-stem `pęť`…`desęť` (kosť-class), adjectival ordinals (`pŕvy`, `drugy`…).

## Note

`veś`'s feminine acc/ins come out `vsų`/`vsejų` (consistent with the crate's own soft-adjective paradigm) rather than the older `vsu`/`vseju` — deliberately one convention across pronouns and adjectives.

## Tests

Golden single-form tests for every class (built from the downstream project's verified paradigm forms: `togo`/`tomu`/`tojų`, `mojego`/`mojejų`, `kogo`, `trěh`, `pęti`/`pęťjų`, …), plus unrecognized→`None` and doctests on both facade methods. `cargo test --workspace` green (incl. doctests); `cargo clippy --workspace` clean.