### PR TITLE
Make verb inflection total; add checked try_* variants (no more panics)

### DIFF
--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -237,15 +237,76 @@ impl ISVCore {
         }
     }
 
+    /// One finite verb form, or `None` when `word` is not a conjugable verb —
+    /// the checked counterpart of [`ISVCore::conjugate_verb_with_options`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn conjugate_verb_checked(
+        word: &str,
+        present_hint: &str,
+        person: &Person,
+        number: &Number,
+        gender: &Gender,
+        tense: &Tense,
+        transitive: bool,
+        imperfective: bool,
+    ) -> Option<String> {
+        let paradigm =
+            ISVCore::verb_paradigm_checked(word, present_hint, transitive, imperfective)?;
+        Some(match tense {
+            Tense::Present => ISVCore::finite_slot(&paradigm.present, person, number),
+            Tense::Imperfect => ISVCore::finite_slot(&paradigm.imperfect, person, number),
+            Tense::Future => ISVCore::finite_slot(&paradigm.future, person, number),
+            Tense::Perfect => {
+                ISVCore::gendered_compound_slot(&paradigm.perfect, person, number, gender)
+            }
+            Tense::PluPerfect => {
+                ISVCore::gendered_compound_slot(&paradigm.pluperfect, person, number, gender)
+            }
+            Tense::Conditional => {
+                ISVCore::gendered_compound_slot(&paradigm.conditional, person, number, gender)
+            }
+        })
+    }
+
+    /// The full verb paradigm. Total: it never panics. A word whose infinitive
+    /// stem cannot be derived falls back to the last-two-characters-stripped
+    /// stem (the same best-effort [`ISVCore::get_infinitive_stem`] uses); call
+    /// [`ISVCore::verb_paradigm_checked`] to detect that case instead of
+    /// silently degrading.
     pub fn verb_paradigm_with_options(
         word: &str,
         present_hint: &str,
         transitive: bool,
         imperfective: bool,
     ) -> VerbParadigm {
+        ISVCore::verb_paradigm_inner(word, present_hint, transitive, imperfective, false)
+            .unwrap_or_else(|| ISVCore::empty_phrase_verb_paradigm(word.trim()))
+    }
+
+    /// The full verb paradigm, or `None` when `word` is not a conjugable verb
+    /// (its infinitive stem cannot be derived). The checked counterpart of
+    /// [`ISVCore::verb_paradigm_with_options`], which falls back instead of
+    /// signalling — use this to distinguish a real verb from arbitrary input
+    /// without a `catch_unwind` guard.
+    pub fn verb_paradigm_checked(
+        word: &str,
+        present_hint: &str,
+        transitive: bool,
+        imperfective: bool,
+    ) -> Option<VerbParadigm> {
+        ISVCore::verb_paradigm_inner(word, present_hint, transitive, imperfective, true)
+    }
+
+    fn verb_paradigm_inner(
+        word: &str,
+        present_hint: &str,
+        transitive: bool,
+        imperfective: bool,
+        strict: bool,
+    ) -> Option<VerbParadigm> {
         let word = word.trim();
         if word.split_whitespace().nth(1).is_some() {
-            return ISVCore::empty_phrase_verb_paradigm(word);
+            return Some(ISVCore::empty_phrase_verb_paradigm(word));
         }
 
         let normalized = match word {
@@ -254,11 +315,15 @@ impl ISVCore {
         };
         let pref = ISVCore::sonic_prefix(normalized);
         let clean_hint = ISVCore::clean_present_hint(present_hint);
-        let Some(infinitive_stem) =
-            ISVCore::sonic_infinitive_stem_with_hint(&pref, normalized, &clean_hint)
-        else {
-            panic!("IMPROPER PRESENT TENSE STEM: {}", word);
-        };
+        // An underivable stem is reported as `None` in strict mode; otherwise
+        // it degrades to the best-effort stem `get_infinitive_stem` uses, so
+        // the total entry point never panics on non-verb input.
+        let infinitive_stem =
+            match ISVCore::sonic_infinitive_stem_with_hint(&pref, normalized, &clean_hint) {
+                Some(stem) => stem,
+                None if strict => return None,
+                None => ISVUTILS::string_without_last_n(normalized, 2),
+            };
         let present_stem =
             ISVCore::sonic_present_tense_stem_from_parts(&pref, &clean_hint, &infinitive_stem);
         let secondary_stem = ISVCore::secondary_present_tense_stem(&present_stem);
@@ -279,7 +344,7 @@ impl ISVCore {
         let pfpp = transitive.then(|| computed_pfpp.clone());
         let gerund = ISVCore::build_gerund(&computed_pfpp);
 
-        VerbParadigm {
+        Some(VerbParadigm {
             infinitive,
             present,
             imperfect,
@@ -293,7 +358,7 @@ impl ISVCore {
             pfap,
             pfpp,
             gerund,
-        }
+        })
     }
 
     fn empty_phrase_verb_paradigm(word: &str) -> VerbParadigm {
@@ -444,10 +509,17 @@ impl ISVCore {
                 pts = pts[3..].to_string();
             }
             if !prefix.is_empty() {
-                if pts.contains(prefix) {
-                    pts = pts[prefix.len()..].to_string();
-                } else if !prefix.is_empty() && pts.len() >= prefix.len() - 1 {
-                    pts = pts[prefix.len() - 1..].to_string();
+                // Strip the prefix off the present hint, char-boundary safe.
+                // `strip_prefix` replaces the old `contains` + byte-index slice
+                // that could panic when the prefix contained a multibyte char.
+                if let Some(rest) = pts.strip_prefix(prefix) {
+                    pts = rest.to_string();
+                } else {
+                    let mut short = prefix.to_string();
+                    short.pop(); // prefix minus its last char, on a boundary
+                    if let Some(rest) = pts.strip_prefix(short.as_str()) {
+                        pts = rest.to_string();
+                    }
                 }
             }
             if pts.ends_with(['m', 'e', 'u', 'ų', '-']) {

--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -221,6 +221,18 @@ impl ISVCore {
     ) -> String {
         let paradigm =
             ISVCore::verb_paradigm_with_options(word, present_hint, transitive, imperfective);
+        ISVCore::verb_slot(&paradigm, person, number, gender, tense)
+    }
+
+    /// Pick one finite form out of an already-built paradigm — the shared slot
+    /// selector for the total and checked conjugation entry points.
+    fn verb_slot(
+        paradigm: &VerbParadigm,
+        person: &Person,
+        number: &Number,
+        gender: &Gender,
+        tense: &Tense,
+    ) -> String {
         match tense {
             Tense::Present => ISVCore::finite_slot(&paradigm.present, person, number),
             Tense::Imperfect => ISVCore::finite_slot(&paradigm.imperfect, person, number),
@@ -237,7 +249,8 @@ impl ISVCore {
         }
     }
 
-    /// One finite verb form, or `None` when `word` is not a conjugable verb —
+    /// One finite verb form, or `None` when an infinitive stem cannot be
+    /// derived from `word` (roughly, it does not look like an infinitive) —
     /// the checked counterpart of [`ISVCore::conjugate_verb_with_options`].
     #[allow(clippy::too_many_arguments)]
     pub fn conjugate_verb_checked(
@@ -252,20 +265,7 @@ impl ISVCore {
     ) -> Option<String> {
         let paradigm =
             ISVCore::verb_paradigm_checked(word, present_hint, transitive, imperfective)?;
-        Some(match tense {
-            Tense::Present => ISVCore::finite_slot(&paradigm.present, person, number),
-            Tense::Imperfect => ISVCore::finite_slot(&paradigm.imperfect, person, number),
-            Tense::Future => ISVCore::finite_slot(&paradigm.future, person, number),
-            Tense::Perfect => {
-                ISVCore::gendered_compound_slot(&paradigm.perfect, person, number, gender)
-            }
-            Tense::PluPerfect => {
-                ISVCore::gendered_compound_slot(&paradigm.pluperfect, person, number, gender)
-            }
-            Tense::Conditional => {
-                ISVCore::gendered_compound_slot(&paradigm.conditional, person, number, gender)
-            }
-        })
+        Some(ISVCore::verb_slot(&paradigm, person, number, gender, tense))
     }
 
     /// The full verb paradigm. Total: it never panics. A word whose infinitive
@@ -283,11 +283,16 @@ impl ISVCore {
             .unwrap_or_else(|| ISVCore::empty_phrase_verb_paradigm(word.trim()))
     }
 
-    /// The full verb paradigm, or `None` when `word` is not a conjugable verb
-    /// (its infinitive stem cannot be derived). The checked counterpart of
-    /// [`ISVCore::verb_paradigm_with_options`], which falls back instead of
-    /// signalling — use this to distinguish a real verb from arbitrary input
-    /// without a `catch_unwind` guard.
+    /// The full verb paradigm, or `None` when an infinitive stem cannot be
+    /// derived from `word` — the checked counterpart of
+    /// [`ISVCore::verb_paradigm_with_options`], which falls back to a
+    /// best-effort stem instead of signalling. Use it to reject clearly
+    /// non-verb input without a `catch_unwind` guard.
+    ///
+    /// The check is mechanical, not lexical: a stem is derivable from anything
+    /// shaped like an infinitive (ending in `-ti`/`-t`/`-ť`), so a `-t`/`-ť`
+    /// noun such as `kosť` still yields `Some`. It returns `None` for input
+    /// that cannot be a verb stem at all (empty, `voda`, `xyz`).
     pub fn verb_paradigm_checked(
         word: &str,
         present_hint: &str,

--- a/crates/interslavic/src/lib.rs
+++ b/crates/interslavic/src/lib.rs
@@ -190,6 +190,40 @@ impl ISV {
         ISVCore::conjugate_verb(trimmed, &person, &number, &gender, &tense)
     }
 
+    /// One finite verb form, or `None` when `word` is not a conjugable verb.
+    /// The checked counterpart of [`ISV::verb`]: it reports non-verb input as
+    /// `None` instead of degrading to a best-effort string, so callers need no
+    /// `catch_unwind` guard to tell the two apart.
+    ///
+    /// ```
+    /// use interslavic::*;
+    /// assert!(ISV::try_verb("pisati", Person::First, Number::Singular, Gender::Masculine, Tense::Present).is_some());
+    /// assert_eq!(ISV::try_verb("xyz", Person::First, Number::Singular, Gender::Masculine, Tense::Present), None);
+    /// ```
+    pub fn try_verb(
+        word: &str,
+        person: Person,
+        number: Number,
+        gender: Gender,
+        tense: Tense,
+    ) -> Option<String> {
+        let trimmed = word.trim();
+        let entries = lookup_verbs_by_lemma(trimmed);
+        if let Some(entry) = entries.first() {
+            return ISVCore::conjugate_verb_checked(
+                entry.lemma,
+                entry.addition,
+                &person,
+                &number,
+                &gender,
+                &tense,
+                entry.transitive,
+                entry.imperfective,
+            );
+        }
+        ISVCore::conjugate_verb_checked(trimmed, "", &person, &number, &gender, &tense, true, true)
+    }
+
     /// One finite verb form with an explicit dictionary present-stem hint.
     ///
     /// This is intended for typed dictionary rows that have multiple entries for
@@ -225,6 +259,28 @@ impl ISV {
             );
         }
         ISVCore::verb_paradigm_with_options(trimmed, "", true, true)
+    }
+
+    /// The full verb paradigm, or `None` when `word` is not a conjugable verb —
+    /// the checked counterpart of [`ISV::verb_forms`].
+    ///
+    /// ```
+    /// use interslavic::*;
+    /// assert!(ISV::try_verb_forms("pisati").is_some());
+    /// assert_eq!(ISV::try_verb_forms("xyz"), None);
+    /// ```
+    pub fn try_verb_forms(word: &str) -> Option<VerbParadigm> {
+        let trimmed = word.trim();
+        let entries = lookup_verbs_by_lemma(trimmed);
+        if let Some(entry) = entries.first() {
+            return ISVCore::verb_paradigm_checked(
+                entry.lemma,
+                entry.addition,
+                entry.transitive,
+                entry.imperfective,
+            );
+        }
+        ISVCore::verb_paradigm_checked(trimmed, "", true, true)
     }
 
     /// Full verb paradigm with explicit dictionary metadata.

--- a/crates/interslavic/src/lib.rs
+++ b/crates/interslavic/src/lib.rs
@@ -190,10 +190,12 @@ impl ISV {
         ISVCore::conjugate_verb(trimmed, &person, &number, &gender, &tense)
     }
 
-    /// One finite verb form, or `None` when `word` is not a conjugable verb.
-    /// The checked counterpart of [`ISV::verb`]: it reports non-verb input as
-    /// `None` instead of degrading to a best-effort string, so callers need no
-    /// `catch_unwind` guard to tell the two apart.
+    /// One finite verb form, or `None` when an infinitive stem cannot be
+    /// derived from `word` (roughly, it does not end in `-ti`/`-t`/`-ť`). The
+    /// checked counterpart of [`ISV::verb`]: it reports clearly non-verb input
+    /// as `None` instead of degrading to a best-effort string, so callers need
+    /// no `catch_unwind` guard. The check is mechanical, not lexical — a `-t`
+    /// noun shaped like an infinitive still yields `Some`.
     ///
     /// ```
     /// use interslavic::*;
@@ -261,8 +263,9 @@ impl ISV {
         ISVCore::verb_paradigm_with_options(trimmed, "", true, true)
     }
 
-    /// The full verb paradigm, or `None` when `word` is not a conjugable verb —
-    /// the checked counterpart of [`ISV::verb_forms`].
+    /// The full verb paradigm, or `None` when an infinitive stem cannot be
+    /// derived from `word` — the checked counterpart of [`ISV::verb_forms`].
+    /// The check is mechanical (infinitive shape), not a lexical verb lookup.
     ///
     /// ```
     /// use interslavic::*;

--- a/crates/interslavic/tests/no_panic.rs
+++ b/crates/interslavic/tests/no_panic.rs
@@ -1,0 +1,78 @@
+use interslavic::*;
+
+// Issue #10: the verb APIs must be total (never panic). Previously
+// ISV::verb / ISV::verb_forms panicked ("IMPROPER PRESENT TENSE STEM") on any
+// word whose infinitive stem could not be derived; ISV::verb_with_present_hint
+// could panic on a char boundary when the prefix contained a multibyte char.
+
+#[test]
+fn verb_apis_do_not_panic_on_non_verbs() {
+    // Reaching the end of the loop without unwinding IS the assertion.
+    for w in ["", "  ", "xyz", "voda", "123", "ž", "hello world", "a", "ť"] {
+        let _ = ISV::verb(
+            w,
+            Person::First,
+            Number::Singular,
+            Gender::Masculine,
+            Tense::Present,
+        );
+        let _ = ISV::verb_forms(w);
+    }
+}
+
+#[test]
+fn verb_with_present_hint_does_not_panic() {
+    // The hint path used to byte-slice at prefix.len(); a multibyte prefix
+    // occurring mid-hint could land off a char boundary and panic.
+    for (w, hint) in [
+        ("prědati", "aprě"),
+        ("razbiti", "raz"),
+        ("iti", "prě jde"),
+        ("byti", "ěěě"),
+        ("dělati", "sę dělaje"),
+    ] {
+        let _ = ISV::verb_with_present_hint(
+            w,
+            hint,
+            Person::Third,
+            Number::Singular,
+            Gender::Masculine,
+            Tense::Present,
+        );
+    }
+}
+
+#[test]
+fn try_variants_distinguish_verbs_from_garbage() {
+    assert!(ISV::try_verb_forms("pisati").is_some());
+    assert!(ISV::try_verb_forms("učiti").is_some());
+    assert!(ISV::try_verb_forms("xyz").is_none());
+    assert!(ISV::try_verb_forms("").is_none());
+    assert!(ISV::try_verb_forms("voda").is_none());
+
+    assert!(ISV::try_verb(
+        "pisati",
+        Person::First,
+        Number::Singular,
+        Gender::Masculine,
+        Tense::Present
+    )
+    .is_some());
+    assert!(ISV::try_verb(
+        "xyz",
+        Person::First,
+        Number::Singular,
+        Gender::Masculine,
+        Tense::Present
+    )
+    .is_none());
+}
+
+#[test]
+fn checked_and_total_agree_for_real_verbs() {
+    // The checked path is the same algorithm; for a real verb it must produce
+    // exactly the total paradigm.
+    for w in ["pisati", "učiti", "dělati", "byti"] {
+        assert_eq!(ISV::try_verb_forms(w), Some(ISV::verb_forms(w)), "{w}");
+    }
+}


### PR DESCRIPTION
Closes #10.

## The panics (all in the verb stem path)

1. `verb_paradigm_with_options` (core) called `panic!("IMPROPER PRESENT TENSE STEM: …")` whenever `sonic_infinitive_stem_with_hint` returned `None` — reachable from `ISV::verb` and `ISV::verb_forms` on **any** non-infinitive `&str` (a noun, empty string, punctuation, a numeral passed to the verb API). This is the one that forces downstream callers to wrap every call in `catch_unwind`.
2. The present-hint path (reachable via `ISV::verb_with_present_hint`) byte-sliced at `prefix.len()` after a `contains` check; a multibyte prefix occurring mid-hint could slice **off a char boundary** and panic.

## Fix

- **Total by default**: the paradigm builder is refactored into a shared `verb_paradigm_inner(…, strict)`. In non-strict mode an underivable stem falls back to the last-two-chars-stripped best-effort that `get_infinitive_stem` **already uses** — so `ISV::verb`/`verb_forms` degrade gracefully instead of aborting, matching the crate's existing graceful-degradation contract. Downstream can drop `catch_unwind`.
- **Boundary-safe hint stripping**: `strip_prefix` (plus a prefix-minus-last-char fallback) replaces the `contains` + byte-index slice.
- **Checked variants** for callers who need to *distinguish* a real verb from arbitrary input (the actual downstream ask): `ISVCore::verb_paradigm_checked` / `conjugate_verb_checked`, and the facade `ISV::try_verb` / `ISV::try_verb_forms`, returning `None` when the stem cannot be derived. `Option`, since there is a single failure mode with no useful payload.

## Tests

`no_panic.rs`: `verb`/`verb_forms` no longer panic on garbage (`""`, `xyz`, `voda`, `ž`, …) or on adversarial multibyte hints; `try_*` return `Some` for real verbs and `None` for non-verbs; the checked and total paths agree for real verbs. The existing conjugation suite is unchanged. `grep panic! core` → 0. `cargo test --workspace` green (15 binaries); `cargo clippy --workspace` clean.