### PR TITLE
Add full noun & adjective paradigm structs (ISV::noun_forms / adj_forms) (#20)

### DIFF
--- a/crates/interslavic-core/src/lib.rs
+++ b/crates/interslavic-core/src/lib.rs
@@ -115,6 +115,83 @@ pub struct VerbParadigm {
     pub gerund: String,
 }
 
+/// The case order the paradigm structs store their per-number `Vec`s in.
+pub const CASE_ORDER: [Case; 6] = [
+    Case::Nom,
+    Case::Acc,
+    Case::Gen,
+    Case::Loc,
+    Case::Dat,
+    Case::Ins,
+];
+
+fn case_index(case: Case) -> usize {
+    match case {
+        Case::Nom => 0,
+        Case::Acc => 1,
+        Case::Gen => 2,
+        Case::Loc => 3,
+        Case::Dat => 4,
+        Case::Ins => 5,
+    }
+}
+
+/// A full noun paradigm — the six cases in each number — for one lemma with a
+/// fixed gender and animacy (the counterpart of [`VerbParadigm`] for nouns).
+/// `singular`/`plural` each hold six forms in [`CASE_ORDER`]; index them with
+/// [`NounParadigm::get`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NounParadigm {
+    pub lemma: String,
+    pub gender: NounGender,
+    pub animacy: Animacy,
+    pub singular: Vec<String>,
+    pub plural: Vec<String>,
+}
+
+impl NounParadigm {
+    /// The form for one `(case, number)` cell.
+    pub fn get(&self, case: Case, number: Number) -> &str {
+        let cells = match number {
+            Number::Singular => &self.singular,
+            Number::Plural => &self.plural,
+        };
+        &cells[case_index(case)]
+    }
+}
+
+/// A full adjective paradigm — six cases × two numbers × the four
+/// gender/animacy columns (masculine animate, masculine inanimate, feminine,
+/// neuter; feminine and neuter are animacy-invariant). Each column is
+/// `[singular, plural]`, each a six-form `Vec` in [`CASE_ORDER`]; index the
+/// whole thing with [`AdjParadigm::get`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdjParadigm {
+    pub lemma: String,
+    pub masculine_animate: [Vec<String>; 2],
+    pub masculine_inanimate: [Vec<String>; 2],
+    pub feminine: [Vec<String>; 2],
+    pub neuter: [Vec<String>; 2],
+}
+
+impl AdjParadigm {
+    /// The form for one `(case, number, gender, animacy)` cell. Feminine and
+    /// neuter ignore `animacy`.
+    pub fn get(&self, case: Case, number: Number, gender: Gender, animacy: Animacy) -> &str {
+        let column = match (gender, animacy) {
+            (Gender::Masculine, Animacy::Animate) => &self.masculine_animate,
+            (Gender::Masculine, Animacy::Inanimate) => &self.masculine_inanimate,
+            (Gender::Feminine, _) => &self.feminine,
+            (Gender::Neuter, _) => &self.neuter,
+        };
+        let number_index = match number {
+            Number::Singular => 0,
+            Number::Plural => 1,
+        };
+        &column[number_index][case_index(case)]
+    }
+}
+
 impl CaseEndings {
     pub fn ending(&self, case: &Case, number: &Number) -> &str {
         match number {

--- a/crates/interslavic/examples/showcase.rs
+++ b/crates/interslavic/examples/showcase.rs
@@ -392,6 +392,27 @@ fn facade_finite_verbs() {
 
 /// `ISV::verb_forms`, `ISV::try_verb_forms`, `ISV::verb_forms_with_metadata`.
 fn facade_verb_paradigms() {
+    heading("ISV::noun_forms / adj_forms — full paradigm structs (like verb_forms)");
+    let np = ISV::noun_forms("žena");
+    row(
+        &format!("noun_forms(\"žena\") [{:?}]", np.gender),
+        &format!("sg={:?}", np.singular),
+    );
+    let ap = ISV::adj_forms("dobry");
+    row(
+        "adj_forms(\"dobry\").feminine[sg]",
+        &format!("{:?}", ap.feminine[0]),
+    );
+    row(
+        "  .get(Gen, Sg, Masc, Anim)",
+        ap.get(
+            Case::Gen,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Animate,
+        ),
+    );
+
     heading("ISV::verb_forms — the whole paradigm as a VerbParadigm struct");
     print_paradigm("učiti", &ISV::verb_forms("učiti"));
 

--- a/crates/interslavic/src/lib.rs
+++ b/crates/interslavic/src/lib.rs
@@ -34,8 +34,8 @@
 //! ```
 
 pub use interslavic_core::{
-    cells, orthography, phono, prepositions, Animacy, Case, Gender, NounGender, Number, Person,
-    Tense, VerbParadigm,
+    cells, orthography, phono, prepositions, AdjParadigm, Animacy, Case, Gender, NounGender,
+    NounParadigm, Number, Person, Tense, VerbParadigm, CASE_ORDER,
 };
 // The dependency-free rule engine is also re-exported, so consumers can reach
 // the lower-level dictionary-less API (and the shared morphophonemics helpers)
@@ -90,6 +90,107 @@ impl ISV {
     /// should model particles/complements separately and pass only the adjective.
     pub fn adj(word: &str, case: Case, number: Number, gender: Gender, animacy: Animacy) -> String {
         ISVCore::decline_adj(word, &case, &number, &gender, animacy)
+    }
+
+    /// The whole noun paradigm — every case in both numbers — with gender and
+    /// animacy inferred from the dictionary (falling back to the rule engine's
+    /// guess for out-of-lexicon words), the counterpart of [`ISV::verb_forms`].
+    /// Cells equal the corresponding [`ISV::noun`] calls; index them with
+    /// [`NounParadigm::get`].
+    ///
+    /// ```
+    /// use interslavic::{Case, Number, ISV};
+    /// let p = ISV::noun_forms("žena");
+    /// assert_eq!(p.get(Case::Gen, Number::Singular), "ženy");
+    /// assert_eq!(p.get(Case::Ins, Number::Singular), "ženojų");
+    /// ```
+    pub fn noun_forms(lemma: &str) -> NounParadigm {
+        let trimmed = lemma.trim();
+        let (gender, animacy) = match lookup_nouns_by_lemma(trimmed).first() {
+            Some(entry) => (
+                dictionary_gender_to_api(entry.gender),
+                if entry.animate {
+                    Animacy::Animate
+                } else {
+                    Animacy::Inanimate
+                },
+            ),
+            None => (
+                match ISVCore::guess_gender(trimmed) {
+                    Gender::Masculine => NounGender::Masculine,
+                    Gender::Feminine => NounGender::Feminine,
+                    Gender::Neuter => NounGender::Neuter,
+                },
+                if ISVCore::noun_is_animate(trimmed) {
+                    Animacy::Animate
+                } else {
+                    Animacy::Inanimate
+                },
+            ),
+        };
+        NounParadigm {
+            lemma: trimmed.to_string(),
+            gender,
+            animacy,
+            singular: CASE_ORDER
+                .iter()
+                .map(|&c| Self::noun(trimmed, c, Number::Singular))
+                .collect(),
+            plural: CASE_ORDER
+                .iter()
+                .map(|&c| Self::noun(trimmed, c, Number::Plural))
+                .collect(),
+        }
+    }
+
+    /// The whole noun paradigm with caller-supplied gender and animacy — the
+    /// paradigm counterpart of [`ISV::noun_with`]. Dictionary metadata such as
+    /// fleeting-vowel additions and number restrictions still applies;
+    /// `gender`/`animacy` override the dictionary row.
+    pub fn noun_forms_with(lemma: &str, gender: NounGender, animacy: Animacy) -> NounParadigm {
+        let trimmed = lemma.trim();
+        NounParadigm {
+            lemma: trimmed.to_string(),
+            gender,
+            animacy,
+            singular: CASE_ORDER
+                .iter()
+                .map(|&c| Self::noun_with(trimmed, c, Number::Singular, gender, animacy))
+                .collect(),
+            plural: CASE_ORDER
+                .iter()
+                .map(|&c| Self::noun_with(trimmed, c, Number::Plural, gender, animacy))
+                .collect(),
+        }
+    }
+
+    /// The whole adjective paradigm — every case × number × gender/animacy
+    /// column. Purely rule-driven (no dictionary), like [`ISV::adj`]; cells
+    /// equal the corresponding `ISV::adj` calls. Index with [`AdjParadigm::get`].
+    ///
+    /// ```
+    /// use interslavic::{Animacy, Case, Gender, Number, ISV};
+    /// let p = ISV::adj_forms("dobry");
+    /// assert_eq!(p.get(Case::Gen, Number::Singular, Gender::Masculine, Animacy::Animate), "dobrogo");
+    /// assert_eq!(p.get(Case::Nom, Number::Singular, Gender::Feminine, Animacy::Inanimate), "dobra");
+    /// ```
+    pub fn adj_forms(word: &str) -> AdjParadigm {
+        let w = word.trim();
+        let column = |gender: Gender, animacy: Animacy| -> [Vec<String>; 2] {
+            [Number::Singular, Number::Plural].map(|number| {
+                CASE_ORDER
+                    .iter()
+                    .map(|&c| Self::adj(w, c, number, gender, animacy))
+                    .collect()
+            })
+        };
+        AdjParadigm {
+            lemma: w.to_string(),
+            masculine_animate: column(Gender::Masculine, Animacy::Animate),
+            masculine_inanimate: column(Gender::Masculine, Animacy::Inanimate),
+            feminine: column(Gender::Feminine, Animacy::Inanimate),
+            neuter: column(Gender::Neuter, Animacy::Inanimate),
+        }
     }
 
     /// The synthetic comparative of an adjective, as `(comparative adjective,

--- a/crates/interslavic/tests/paradigms.rs
+++ b/crates/interslavic/tests/paradigms.rs
@@ -1,0 +1,136 @@
+use interslavic::*;
+
+const CASES: [Case; 6] = CASE_ORDER;
+const NUMBERS: [Number; 2] = [Number::Singular, Number::Plural];
+
+#[test]
+fn noun_forms_cells_equal_single_form_calls() {
+    // The acceptance criterion: the struct's cells are exactly the per-cell
+    // ISV::noun results, for a spread of declension classes.
+    for lemma in ["žena", "grad", "kosť", "oko", "mųž", "selo", "dělo"] {
+        let p = ISV::noun_forms(lemma);
+        for number in NUMBERS {
+            for case in CASES {
+                assert_eq!(
+                    p.get(case, number),
+                    ISV::noun(lemma, case, number),
+                    "{lemma} {case:?} {number:?}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn noun_forms_with_matches_noun_with() {
+    let p = ISV::noun_forms_with("kosť", NounGender::Feminine, Animacy::Inanimate);
+    assert_eq!(p.gender, NounGender::Feminine);
+    for number in NUMBERS {
+        for case in CASES {
+            assert_eq!(
+                p.get(case, number),
+                ISV::noun_with(
+                    "kosť",
+                    case,
+                    number,
+                    NounGender::Feminine,
+                    Animacy::Inanimate
+                ),
+            );
+        }
+    }
+}
+
+#[test]
+fn adj_forms_cells_equal_single_form_calls() {
+    for word in ["dobry", "svěži"] {
+        let p = ISV::adj_forms(word);
+        for number in NUMBERS {
+            for case in CASES {
+                for (gender, animacy) in [
+                    (Gender::Masculine, Animacy::Animate),
+                    (Gender::Masculine, Animacy::Inanimate),
+                    (Gender::Feminine, Animacy::Inanimate),
+                    (Gender::Neuter, Animacy::Inanimate),
+                ] {
+                    assert_eq!(
+                        p.get(case, number, gender, animacy),
+                        ISV::adj(word, case, number, gender, animacy),
+                        "{word} {case:?} {number:?} {gender:?} {animacy:?}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn paradigm_golden_forms() {
+    let z = ISV::noun_forms("žena");
+    assert_eq!(z.gender, NounGender::Feminine);
+    assert_eq!(z.get(Case::Gen, Number::Singular), "ženy");
+    assert_eq!(z.get(Case::Ins, Number::Singular), "ženojų");
+    assert_eq!(z.get(Case::Gen, Number::Plural), "žen");
+
+    let d = ISV::adj_forms("dobry");
+    assert_eq!(
+        d.get(
+            Case::Gen,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Animate
+        ),
+        "dobrogo"
+    );
+    // Feminine and neuter ignore animacy.
+    assert_eq!(
+        d.get(
+            Case::Nom,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Animate
+        ),
+        d.get(
+            Case::Nom,
+            Number::Singular,
+            Gender::Feminine,
+            Animacy::Inanimate
+        ),
+    );
+    // Masculine accusative singular differs by animacy.
+    assert_eq!(
+        d.get(
+            Case::Acc,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Animate
+        ),
+        "dobrogo"
+    );
+    assert_eq!(
+        d.get(
+            Case::Acc,
+            Number::Singular,
+            Gender::Masculine,
+            Animacy::Inanimate
+        ),
+        "dobry"
+    );
+}
+
+#[test]
+fn paradigm_shapes_are_well_formed() {
+    let n = ISV::noun_forms("grad");
+    assert_eq!(n.singular.len(), 6);
+    assert_eq!(n.plural.len(), 6);
+    let a = ISV::adj_forms("dobry");
+    for col in [
+        &a.masculine_animate,
+        &a.masculine_inanimate,
+        &a.feminine,
+        &a.neuter,
+    ] {
+        assert_eq!(col[0].len(), 6);
+        assert_eq!(col[1].len(), 6);
+    }
+}


### PR DESCRIPTION
Closes #20.

## What

Symmetric with the existing `verb_forms` — `NounParadigm` / `AdjParadigm` structs in interslavic-core (re-exported), plus facade builders:

```rust
ISV::noun_forms(lemma)                     -> NounParadigm  // gender/animacy inferred from the dictionary
ISV::noun_forms_with(lemma, gender, anim)  -> NounParadigm  // explicit
ISV::adj_forms(word)                       -> AdjParadigm   // pure, no dictionary (like ISV::adj)
```

`NounParadigm` holds `singular`/`plural` (6 forms each, in the exported `CASE_ORDER`); `AdjParadigm` holds the four gender/animacy columns (masc-anim, masc-inan, feminine, neuter), each `[singular, plural]`. Both provide a `get(case, number[, gender, animacy])` accessor.

## Design

The builders **loop the existing single-form `ISV::noun`/`noun_with`/`adj` methods**, so every cell equals the corresponding single-form call *by construction* — which is exactly this issue's proposed acceptance criterion. No new engine logic, no gender-conversion or dictionary duplication. A test asserts the equality across seven noun declension classes and both adjective classes; golden forms are pinned (`žena`, `dobry` including the animacy-sensitive masc.acc.sg).

Consumers that reconstruct full paradigms cell by cell today can consume the struct directly.

## Tests

Cells-equal-single-form (the acceptance test), `noun_forms_with` ↔ `noun_with`, golden forms, well-formed shapes; doctests on `noun_forms` and `adj_forms`; showcase updated. `cargo test --workspace` green; `cargo clippy --workspace --all-targets` clean.